### PR TITLE
fix: removed DatabaseType and QueueType from config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,40 +1,18 @@
 package config
 
-type DatabaseType string
-
-func (dt DatabaseType) String() string {
-	return string(dt)
-}
-
-const (
-	DatabaseTypePostgres DatabaseType = "postgres"
-)
-
-type QueueType string
-
-func (qt QueueType) String() string {
-	return string(qt)
-}
-
-const (
-	QueueTypeNATS QueueType = "nats"
-)
-
 type Config struct {
 	ServerHost string `viper:"DRIFTHOOK_SERVER_HOST"`
 	ServerPort int    `viper:"DRIFTHOOK_SERVER_PORT"`
 
-	DatabaseType     string `viper:"DRIFTHOOK_DATABASE_TYPE"`
 	DatabaseHost     string `viper:"DRIFTHOOK_DATABASE_HOST"`
 	DatabasePort     int    `viper:"DRIFTHOOK_DATABASE_PORT"`
-	DatabaseUser     string `viper:"DRIFTHOOK_DATABASE_USER"`
+	DatabaseUsername string `viper:"DRIFTHOOK_DATABASE_USERNAME"`
 	DatabasePassword string `viper:"DRIFTHOOK_DATABASE_PASSWORD"`
 	DatabaseName     string `viper:"DRIFTHOOK_DATABASE_NAME"`
 	DatabaseOptions  string `viper:"DRIFTHOOK_DATABASE_OPTIONS"`
 
-	QueueType     string   `viper:"DRIFTHOOK_QUEUE_TYPE"`
 	QueueUrls     []string `viper:"DRIFTHOOK_QUEUE_URLS"`
-	QueueUser     string   `viper:"DRIFTHOOK_QUEUE_USER"`
+	QueueUsername string   `viper:"DRIFTHOOK_QUEUE_USERNAME"`
 	QueuePassword string   `viper:"DRIFTHOOK_QUEUE_PASSWORD"`
 }
 
@@ -42,16 +20,14 @@ var DefaultConfig = Config{
 	ServerHost: "localhost",
 	ServerPort: 8080,
 
-	DatabaseType:     "postgres",
 	DatabaseHost:     "localhost",
 	DatabasePort:     5432,
-	DatabaseUser:     "postgres",
+	DatabaseUsername: "postgres",
 	DatabasePassword: "postgres",
 	DatabaseName:     "drifthook",
 	DatabaseOptions:  "",
 
-	QueueType:     "nats",
 	QueueUrls:     []string{"nats://localhost:4222"},
-	QueueUser:     "",
+	QueueUsername: "",
 	QueuePassword: "",
 }


### PR DESCRIPTION
## Configuration Update: Simplification

To streamline our configuration, we've made the following changes:

Database: Only Postgres and Postgres-compatible databases are supported.
Queue: Only NATS Jetstream is supported.

As a result, the DatabaseType and QueueType configuration options have been removed.